### PR TITLE
Clean up documentation (minus kapacitor) a bit.

### DIFF
--- a/chronograf/content.md
+++ b/chronograf/content.md
@@ -6,66 +6,40 @@ Chronograf is a simple to install graphing and visualization application that yo
 
 ## Using this image
 
-### Exposed Ports
-
--	10000 (default port)
-
-### Using the default configuration
-
-By default, Chronograf runs on localhost port `10000`. Chronograf exposes a shared volume under `/var/lib/chronograf`, which it uses to store database data. You can mount a host directory to `/var/lib/chronograf` for host access to persisted container data. A typical invocation of the Chronograf container might be:
+By default, Chronograf listens on port `10000` and stores its data in a volume at `/var/lib/chronograf`. You can start an instance with:
 
 ```console
-$ docker run --net=host \
-      -v /path/on/host:/var/lib/chronograf \
-      chronograf
+$ docker run -p 10000:10000 chronograf
 ```
 
-You can also have Docker control the volume mountpoint by using a named volume.
-
-```console
-$ docker run -p 10000:10000 \
-      -v chronograf:/var/lib/chronograf \
-      chronograf
-```
+You can also use a custom configuration file or environment variables to modify Chronograf settings.
 
 ### Using a custom config file
 
-Assuming a custom configuration file on your host at `/path/to/config.toml` you can mount a shared volume as follows:
+A sample configuration file can be obtained by:
 
 ```console
-$ docker run --net=host \
-      -v /path/to:/opt/chronograf:ro \
-      chronograf -config /opt/chronograf/config.toml
+$ docker run --rm chronograf -sample-config > chronograf.toml
 ```
 
-## Config variables
-
-Chronograf 0.10 has following config variables
-
-| FLAG                    | ENV VAR                               | DEFAULT VALUE                     |
-|-------------------------|---------------------------------------|-----------------------------------|
-| LocalDatabase           | CHRONOGRAF_LOCAL_DATABASE             | /var/lib/chronograf/chronograf.db |
-| QueryResponseBytesLimit | CHRONOGRAF_QUERY_RESPONSE_BYTES_LIMIT | 2500000                           |
-
-All of these can be provided in the config file or overrided using the environment variables
-
-### Binding to a different port
-
-To bind to a different port you can use Docker's `-p` flag. For example, to run Chronograf on port `9999`:
+Once you've customized `chronograf.conf`, you can run the Chronograf container with it mounted in the expected location (note the name change!):
 
 ```console
-docker run -p 9999:10000 chronograf
+$ docker run -d \
+      -p 10000:10000 \
+      -v /path/to/chronograf.toml:/opt/chronograf/config.toml
 ```
 
-### Using a different database file
+### Using environment variables (preferred)
 
-```console
-$ docker run --net=host \
-      -v /path/on/host/:/var/lib/other_chronograf.db \
-      --env CHRONOGRAF_LOCAL_DATABASE=/var/lib/other_chronograf db \
-      chronograf
-```
+You may have noticed that the default `Bind` value in the configuration is set to `127.0.0.1:10000`, though the container will listen on `0.0.0.0:10000` instead. This is due to a `CHRONOGRAF_BIND` environment variable being set in the Dockerfile to provide a sensible default within the Docker context. Other environment variables can override configuration settings following the `CamelCase` to `CHRONOGRAF_CAMEL_CASE` pattern:
 
-## Official Docs
+| SETTING                 | ENV VAR                               |
+|-------------------------|---------------------------------------|
+| Bind                    | CHRONOGRAF_BIND                       |
+| LocalDatabase           | CHRONOGRAF_LOCAL_DATABASE             |
+| QueryResponseBytesLimit | CHRONOGRAF_QUERY_RESPONSE_BYTES_LIMIT |
+
+## Official Documentation
 
 See the [official docs](https://docs.influxdata.com/chronograf/latest/introduction/getting_started/) for information on creating visualizations.

--- a/influxdb/content.md
+++ b/influxdb/content.md
@@ -51,9 +51,7 @@ InfluxDB can be either configured from a config file or using environment variab
 Generate the default configuration file:
 
 ```console
-$ docker run --rm \
-      -v $PWD:/etc/influxdb \
-      influxdb bash -c 'influxd config > /etc/influxdb/influxdb.conf'
+$ docker run --rm influxdb influxd config > influxdb.conf
 ```
 
 Modify the default configuration, which will now be available under `$PWD`. Then start the InfluxDB container.
@@ -106,10 +104,16 @@ Start the container:
 $ docker run --name=influxdb -d -p 8083:8083 -p 8086:8086 influxdb
 ```
 
-Run the influx client in another container as such:
+Run the influx client in another container:
 
 ```console
 $ docker run --rm --link=influxdb -it influxdb influx -host influxdb
+```
+
+Alternatively, jump directly into the container:
+
+```console
+$ docker exec -it influxdb influx
 ```
 
 ### Web Administrator Interface

--- a/telegraf/content.md
+++ b/telegraf/content.md
@@ -14,99 +14,100 @@ Telegraf is an open source agent written in Go for collecting metrics and data o
 -	8092 UDP
 -	8094 TCP
 
-### Using default config
+### Using the default configuration
 
 The default configuration requires a running InfluxDB instance as an output plugin. Ensure that InfluxDB is running on port 8086 before starting the Telegraf container.
 
 Minimal example to start an InfluxDB container:
 
 ```console
-$ docker run -p 8083:8083 -p 8086:8086 influxdb
+$ docker run -d --name influxdb -p 8083:8083 -p 8086:8086 influxdb
 ```
 
-Starting Telegraf using default config:
+Starting Telegraf using the default config, which connects to InfluxDB at `http://localhost:8086/`:
 
 ```console
-$ docker run --net=host telegraf
+$ docker run --net=container:influxdb telegraf
 ```
 
 ### Using a custom config file
 
-First generate a sample configuration and save it under `/path/on/host/telegraf.conf` on the host:
+First, generate a sample configuration and save it as `telegraf.conf` on the host:
 
 ```console
-$ docker run --rm \
-      telegraf -sample-config > /path/on/host/telegraf.config
+$ docker run --rm telegraf -sample-config > telegraf.conf
 ```
 
-Then, once you've customised `/path/on/host/telegraf.conf`, you can run the Telegraf container with the configuration file mounted in the shared volume Telegraf expects to find its configuration:
+Once you've customized `telegraf.conf`, you can run the Telegraf container with it mounted in the expected location:
 
 ```console
-$ docker run -v /path/on/host/:/etc/telegraf:ro telegraf
+$ docker run -v /path/to/telegraf.conf:/etc/telegraf/telegraf.conf:ro telegraf
 ```
 
 Read more about the Telegraf configuration [here](https://docs.influxdata.com/telegraf/latest/introduction/configuration/).
 
 ### Using the container with input plugins
 
-These examples assume you are using a custom configuration file which you're mounting into the container as a shared volume.
-
-In each case you need to create a Docker bridge network. For these examples we'll assume that the following command has been run:
+These examples assume you are using a custom configuration file that takes advantage of Docker's built-in service discovery capability. In order to do so, we'll first create a new network:
 
 ```console
-$ docker network create --driver bridge telegraf_nw
+$ docker network create telegraf_nw
+```
+
+Next, we'll start our InfluxDB container named `influxdb`:
+
+```console
+$ docker run -d --name influxdb \
+      --net=telegraf_nw \
+      -p 8083:8083 -p 8086:8086 \
+      influxdb
+```
+
+The `telegraf.conf` configuration can now resolve the `influxdb` container by name:
+
+```toml
+[[outputs.influxdb]]
+	urls = ["http://influxdb:8086"]
+```
+
+Finally, we start our Telegraf container and verify functionality:
+
+```console
+$ docker run -d --name telegraf \
+      --net=telegraf_nw \
+      -v /path/to/telegraf.conf:/etc/telegraf/telegraf.conf:ro \
+      telegraf
+...
+$ docker logs -f telegraf
 ```
 
 #### Aerospike
 
-First start aerospike in a container, ensuring it's added to the `telegraf_nw` bridge network:
+Start an instance of aerospike:
 
 ```console
-$ docker run -d \
+$ docker run -d --name aerospike \
       --net=telegraf_nw \
-      --name aerospike \
-      -p 3000:3000 -p 3001:3001 -p 3002:3002 -p 3003:3003 \
+      -p 3000-3003:3000-3003 \
       aerospike
 ```
 
-Edit your Telegraf config file and specify the correct aerospike host and port:
+Edit your Telegraf config file and set the correct connection parameter for Aerospike:
 
 ```toml
 [[inputs.aerospike]]
 	servers = ["aerospike:3000"]
 ```
 
-Start the InfluxDB container:
+Restart your `telegraf` container to pick up the changes:
 
 ```console
-$ docker run -d -P \
-      --net=telegraf_nw \
-      --name influxdb \
-      influxdb
-```
-
-Configure it correctly as an output plugin in your Telegraf config:
-
-```toml
-[[outputs.influxdb]]
-	urls = ["http://influxdb:8086"]
-	database = "telegraf"
-	precision = "s"
-	timeout = "5s"
-```
-
-Start Telegraf as follows, assuming your Telegraf configuration file is located at `/path/on/host/telegraf.conf`:
-
-```console
-$ docker run -d \
-      --net=telegraf_nw \
-      -v /path/on/host:/etc/telegraf:ro \
-      telegraf
+$ docker restart telegraf
 ```
 
 #### Nginx
 
-Assuming an nginx configuration at `/path/on/host/nginx.conf`, modify the nginx default config:
+Create an `nginx_status.conf` configuration file to expose metric data:
 
 ```nginx
 server {
@@ -118,32 +119,29 @@ server {
 }
 ```
 
-Start the nginx container:
+Start an Nginx container utilizing it:
 
 ```console
-$ docker run --name=nginx \
+$ docker run -d --name=nginx \
       --net=telegraf_nw \
       -p 8090:8090 -p 8080:80 \
-      -v /path/on/host:/etc/nginx:ro \
+      -v /path/to/nginx_status.conf:/etc/nginx/conf.d/nginx_status.conf:ro \
       nginx
 ```
 
 Verify the status page: [http://localhost:8090/nginx_status](http://localhost:8090/nginx_status).
 
-Configure the nginx input plugin on your Telegraf configuration:
+Configure the nginx input plugin in your Telegraf configuration file:
 
 ```toml
 [[inputs.nginx]]
-  urls = ["http://nginx/nginx_status"]
+  urls = ["http://nginx:8090/nginx_status"]
 ```
 
-Run Telegraf using the config file:
+Restart your `telegraf` container to pick up the changes:
 
 ```console
-$ docker run -d \
-      --net=telegraf_nw \
-      -v /path/on/host:/etc/telegraf:ro \
-      telegraf
+$ docker restart telegraf
 ```
 
 #### StatsD
@@ -153,10 +151,10 @@ Telegraf has a StatsD plugin, allowing Telegraf to run as a StatsD server that m
 Run Telegraf with the UDP port 8125 exposed:
 
 ```console
-$ docker run -d \
+$ docker run -d --name telegraf \
       --net=telegraf_nw \
       -p 8125:8125/udp \
-      -v /path/on/host:/etc/telegraf:ro \
+      -v /path/to/telegraf.conf:/etc/telegraf/telegraf.conf:ro \
       telegraf
 ```
 
@@ -168,8 +166,8 @@ $ for i in {1..50}; do echo $i;echo "foo:1|c" | nc -u -w0 127.0.0.1 8125; done
 
 Check that the measurement `foo` is added in the DB.
 
-### Supported Plugins
+### Supported Plugins Reference
 
-[Output](https://docs.influxdata.com/telegraf/latest/outputs/)
+-	[Input Plugins](https://docs.influxdata.com/telegraf/latest/outputs/)
 
-[Input](https://docs.influxdata.com/telegraf/latest/outputs/)
+-	[Output Plugins](https://docs.influxdata.com/telegraf/latest/outputs/)


### PR DESCRIPTION
Revamp the documentation, but leaving Kapacitor as an exercise for the InfluxDB folks.  Primarily, it should not recommend `--net=host`, and instead provide guidance on setting it up on top of influxdb in a similar style to what was done for telegraf.
